### PR TITLE
feat: allow default colors and mismatched lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v3.1.0 (2023-08-14)
+
+- Removes the validation requiring the colors array to match the length of the columns. When no color is passed for a column, the formatting will be reset to default
+- Introduces the `Colors.none` enum to be used instead of `None` on the colors array
+
 ## v3.0.0 (2023-07-01)
 
 - Drops support for Python 3.7

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ You can also color each column differently by using the `colors` argument and pa
 - bold
 - reset (resets all text formatting)
 - underline
+- none (acts like reset, used instead of passing `None` as a color)
 
 ## Development
 

--- a/pretty_tables/formatting.py
+++ b/pretty_tables/formatting.py
@@ -24,6 +24,7 @@ class Colors:
     bold = '\033[1m'
     reset = '\033[0m'  # Resets all text formatting
     underline = '\033[4m'
+    none = '\033[0m'  # Same as `reset`
 
 
 def _format_table(table: List[Any], colors: Optional[List[Colors]] = None, truthy: Optional[int] = None) -> str:
@@ -57,13 +58,7 @@ def _format_table(table: List[Any], colors: Optional[List[Colors]] = None, truth
                 + table_right_boder
             )
 
-        # Check if truthy
         if truthy:
-            # Check if the input has the correct number of colors for truthy coloring
-            valid_num_color_entries = {0, 2}
-            if colors and (len(colors) not in valid_num_color_entries):
-                raise ValueError('When using the truthy option, you must specify two colors, or no colors')
-
             # Check that the truthy column exists
             valid_truthy_values = isinstance(truthy, int) and 0 < truthy < len(line)
             if not valid_truthy_values:
@@ -88,7 +83,8 @@ def _format_table(table: List[Any], colors: Optional[List[Colors]] = None, truth
             complete_table.append(
                 table_left_border
                 + table_column_divider.join(
-                    f'{colors[i]}{str(item):{col_widths[i]}}{Colors.reset}' for i, item in enumerate(line)
+                    f'{colors[i] if len(colors) > i else Colors.none}{str(item):{col_widths[i]}}{Colors.reset}'
+                    for i, item in enumerate(line)
                 )
                 + table_right_boder
             )

--- a/pretty_tables/tables.py
+++ b/pretty_tables/tables.py
@@ -71,8 +71,11 @@ def _validate_table_input(
     if colors:
         if not isinstance(colors, list):
             raise ValueError('Colors are set but are not a proper list.')
-        elif not truthy and len(colors) != len(headers):
-            raise IndexError('The number of colors does not match the number of columns.')
+        if truthy:
+            # Check if the input has the correct number of colors for truthy coloring
+            valid_num_color_entries = {0, 2}
+            if colors and (len(colors) not in valid_num_color_entries):
+                raise ValueError('When using the truthy option, you must specify two colors, or no colors')
 
     table_length = len(headers)
     for i, row in enumerate(rows):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fh:
 DEV_REQUIREMENTS = [
     'bandit == 1.7.*',
     'black == 23.*',
-    'build == 0.7.*',
+    'build == 0.10.*',
     'flake8 == 6.*',
     'isort == 5.*',
     'mypy == 1.3.*',
@@ -18,7 +18,7 @@ DEV_REQUIREMENTS = [
 
 setuptools.setup(
     name='pretty-tables',
-    version='3.0.0',
+    version='3.1.0',
     description='Create pretty tables from headers and rows, perfect for console output.',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -3,31 +3,40 @@ import pytest
 import pretty_tables
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def headers():
-    headers = ['ID', 'Name', 'Occupation', 'Employed']
+    return [
+        'ID',
+        'Name',
+        'Occupation',
+        'Employed',
+    ]
 
-    return headers
 
-
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def rows():
-    rows = [
+    return [
         [1, 'Justin', 'Software Engineer', True],
         [2, 'Misty', 'Receptionist', False],
         [3, 'John', None, False],
     ]
 
-    return rows
 
-
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def colors():
-    colors = [
+    return [
         pretty_tables.Colors.blue,
         pretty_tables.Colors.purple,
         pretty_tables.Colors.bold,
         pretty_tables.Colors.green,
     ]
 
-    return colors
+
+@pytest.fixture()
+def colors_partial():
+    """Test a None value inbetween and a missing 4th value"""
+    return [
+        pretty_tables.Colors.blue,
+        pretty_tables.Colors.none,
+        pretty_tables.Colors.purple,
+    ]

--- a/test/unit/test_formatting.py
+++ b/test/unit/test_formatting.py
@@ -22,6 +22,28 @@ def test_create_table_with_colors(headers, rows, colors):
     # fmt: on
 
 
+def test_create_table_with_colors_partial(headers, rows, colors_partial):
+    """Tests that we can use `Colors.none` inbetween other colors as well as use the default color
+    when our colors list doesn't match the length of the data.
+    """
+    output = pretty_tables.create(
+        headers=headers,
+        rows=rows,
+        empty_cell_placeholder='No data',
+        colors=colors_partial,
+    )
+
+    # fmt: off
+    assert output == (
+        '| \x1b[94mID\x1b[0m | \x1b[0mName  \x1b[0m | \x1b[95mOccupation       \x1b[0m | \x1b[0mEmployed\x1b[0m |\n'
+        '| -- | ------ | ----------------- | -------- |\n'
+        '| \x1b[94m1 \x1b[0m | \x1b[0mJustin\x1b[0m | \x1b[95mSoftware Engineer\x1b[0m | \x1b[0mTrue    \x1b[0m |\n'
+        '| \x1b[94m2 \x1b[0m | \x1b[0mMisty \x1b[0m | \x1b[95mReceptionist     \x1b[0m | \x1b[0mFalse   \x1b[0m |\n'
+        '| \x1b[94m3 \x1b[0m | \x1b[0mJohn  \x1b[0m | \x1b[95mNo data          \x1b[0m | \x1b[0mFalse   \x1b[0m |'
+    )
+    # fmt: on
+
+
 def test_create_table_with_default_truthy(headers, rows):
     output = pretty_tables.create(
         headers=headers,
@@ -59,19 +81,6 @@ def test_create_table_with_custom_truthy_colors(headers, rows):
         '| \x1b[95m3 \x1b[0m | \x1b[95mJohn  \x1b[0m | \x1b[95mNo data          \x1b[0m | \x1b[95mFalse   \x1b[0m |'
     )
     # fmt: on
-
-
-def test_create_table_with_default_truthy_not_enough_colors(headers, rows):
-    with pytest.raises(ValueError) as exc:
-        _ = pretty_tables.create(
-            headers=headers,
-            rows=rows,
-            empty_cell_placeholder='No data',
-            colors=[pretty_tables.Colors.cyan],
-            truthy=3,
-        )
-
-    assert 'When using the truthy option, you must specify two colors, or no colors' in str(exc.value)
 
 
 def test_create_table_with_default_truthy_bad_column_index(headers, rows):

--- a/test/unit/test_tables.py
+++ b/test/unit/test_tables.py
@@ -77,17 +77,6 @@ def test_validate_table_input_bad_colors(headers, rows):
     assert 'Colors are set but are not a proper list.' in str(error.value)
 
 
-def test_validate_table_input_colors_bad_length(headers, rows):
-    with pytest.raises(IndexError) as error:
-        _validate_table_input(
-            headers=headers,
-            rows=rows,
-            colors=[1, 2],
-        )
-
-    assert 'The number of colors does not match the number of columns.' in str(error.value)
-
-
 def test_validate_table_input_bad_row_in_rows():
     headers = ['column1']
     rows = [
@@ -114,3 +103,16 @@ def test_validate_table_input_mismatching_column_length():
         )
 
     assert 'Row 1 has 1 column(s) which does not match the table columns of 2.' in str(error.value)
+
+
+def test_validate_table_with_default_truthy_not_enough_colors(headers, rows):
+    with pytest.raises(ValueError) as exc:
+        _ = pretty_tables.create(
+            headers=headers,
+            rows=rows,
+            empty_cell_placeholder='No data',
+            colors=[pretty_tables.Colors.cyan],
+            truthy=3,
+        )
+
+    assert 'When using the truthy option, you must specify two colors, or no colors' in str(exc.value)


### PR DESCRIPTION
Closes #4 by allowing the colors list to not match the length of the columns provided. When colors are not provided for a column, we'll reset the formatting to default. This PR also introduces the `Colors.none` enum to use in place of passing `None` as a color so formatting happens correctly
